### PR TITLE
headroom initilaise with plain js instead of jQuery

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -6,23 +6,16 @@ $(function () {
 	var toggle = $(".burger");
 	var close = $(".close");
 	var HeadroomNav = document.querySelector("nav");
-	var headroom  = new Headroom(HeadroomNav);// 创建 Headroom 对象，将页面元素传递进去
-	
+	var headroom = new Headroom(HeadroomNav); // 创建 Headroom 对象，将页面元素传递进去
 
-	
 	clickBinding(); // binding click functions for toogle, menu and close 
 	toggleMenu(); // trigger toggleMenu function once at beginning
-	// 初始化
-	headroom.init(); 
-	$("nav").headroom("destroy");
-	
+
+	headroom.init(); // 初始化
+
 	$(window).on('resize', function () {
 		toggleMenu(); // trigger toggleMenu function when window resizing
 	});
-	
-
-	
-		
 
 	function toggleMenu() {
 		isLargeWindow = $(window).width() > winSize;
@@ -57,5 +50,5 @@ $(function () {
 			toggle.fadeIn(200);
 		});
 	}
-	
+
 });


### PR DESCRIPTION
Signed-off-by: Wei-Shiang Lian <weishianglian@gmail.com>

## Fix the error from headroom which affects the function of resize. 
The document from official website mentioned that there are three ways to initialise the headroom. All we need to do is choosing a specific one to implement, and in this part you applied is **plian.js**. Therefore, we don't need to declare another way by using jQuery and what I've done is deleting the code `$("nav").headroom("destroy");`.
 
 
 
 
> **Attach a picture to clarify the concept**
<img width="684" alt="Screenshot 2019-05-15 at 00 40 05" src="https://user-images.githubusercontent.com/32001663/57739373-3b6d1300-76ab-11e9-83aa-b28abd8da8e1.png">
